### PR TITLE
Add dockerfile for installing and running Quartus

### DIFF
--- a/dockerfiles/README-Docker.md
+++ b/dockerfiles/README-Docker.md
@@ -25,3 +25,39 @@ display socket, and the `../software/` directory into the container
 prior to running HaasoscopeQt.py.  It may be necessary to copy and
 modify this script to work on your machine.  See the script for
 details.
+
+## Building a container image for the Intel Quartus FPGA software
+
+The Quartus software is used to compile the FPGA firmware.  It can
+also be used to program that firmware into the Haasoscope hardware.
+
+The following command will create a container locally named
+"quartus" that can be used to run the Quartus tool:
+```
+docker build -t quartus -f quartus.docker
+```
+
+Important! Building this container involves a download of over 6GB and
+the full installation requires around 25GB of disk space!
+
+Once the container is built one can run the Quartus GUI in the
+container. See the [quartus.sh](./quartus.sh) file for details.  For
+example:
+```
+./quartus.sh
+```
+
+It is also possible to run an FPGA simulation and compilation from the
+command line:
+```
+./quartus_compile.sh
+```
+
+The firmware image can also be uploaded to the Haasoscope hardware
+from the command line:
+```
+./quartus_flash.sh
+```
+
+The above scripts are examples - it may be necessary to copy and
+modify these scripts for your machine.

--- a/dockerfiles/quartus.docker
+++ b/dockerfiles/quartus.docker
@@ -1,0 +1,65 @@
+# This is a dockerfile for installing and running the Intel Quartus
+# fpga design tool (version 22.1).
+#
+# Build this docker container with something like:
+#  docker build -t quartus -f quartus.docker
+#
+# Important! The Quartus software is over 6GB to download and the
+# installation size is ~25GB!
+#
+# See quartus.sh, quartus_compile.sh, and quartus_flash.sh for
+# information on running the container.
+
+FROM ubuntu:20.04
+
+ARG QUARTUS_URL=https://downloads.intel.com/akdlm/software/acdsinst/22.1std/915/ib_tar/Quartus-lite-22.1std.0.915-linux.tar
+
+# First, get wget so we can download Quartus
+RUN apt-get update && apt-get install -y wget
+
+# Make an install directory, download Quartus and extract Quartus into it.
+RUN mkdir quartus_install \
+    && wget ${QUARTUS_URL} -O quartus.tar \
+    && tar -C quartus_install -xf quartus.tar \
+    && rm quartus.tar
+
+# Define items we don't need in the image. By default, we turn off
+# help and update to keep the image small. The following are valid
+# options: quartus quartus_help devinfo arria_lite cyclone cyclone10lp
+# cyclonev max max10 quartus_update
+ARG QUARTUS_DISABLED="quartus_help,quartus_update"
+
+# Run the Quartus installer and cleanup the install directory when done
+RUN quartus_install/setup.sh --mode unattended --accept_eula 1 --installdir /quartus --disable-components ${QUARTUS_DISABLED}\
+    && rm -rf quartus_install
+
+# Install packages necessary for Quartus to work
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libglib2.0-0 \
+    libpng-dev \
+    libfreetype6 \
+    libsm6 \
+    libxrender1 \
+    libfontconfig1 \
+    libxext6 \
+# for installing locales
+    locales \
+# java needed for platform designer / qsys
+    default-jre \
+# needed for normal init environment
+    dumb-init \
+# Generate the en_US locale
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen en_US.UTF-8 \
+    && update-locale LANG=en_US.UTF-8 \
+# cleanup apt-list
+    && rm -rf /var/lib/apt/lists/*
+
+# Set environment so Quartus is in the path
+ENV PATH="${PATH}:/quartus/quartus/bin"
+
+# Force en_US.UTF8
+ENV LC_ALL="en_US.UTF-8"
+
+# Use dumb-init as an entry point (for proper Unix signal handling)
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/dockerfiles/quartus.sh
+++ b/dockerfiles/quartus.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# This is an example script for running the "Quartus" graphical
+# interface in a docker container.  This is an example - you may need
+# to copy this file and modify it so that it works in your
+# environment.
+#
+# Prior to running this script, the docker image should have been
+# created with something like:
+#  docker build -t quartus -f quartus.docker
+
+# Map x-windows socket into container
+DPARAM="-v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=${DISPLAY}"
+
+# If passing the x-windows socket doesn't work, then the following may
+# work instead:
+#xhost +localhost
+#DPARAM="${DPARAM} --net=host -e DISPLAY=host.docker.internal:0"
+
+# Obtain directory of the haasoscope software (based on the location
+# of this script) and map the local firmware directory to /project .
+SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+DPARAM="${DPARAM} -v ${SRCDIR}/max10_adc_firmware:/project -w /project"
+
+# Run Quartus in container
+docker run -it --rm ${DPARAM} localhost/quartus quartus serial1.qpf "$@"
+
+# If "xhost +localhost" was used above then reenable security here.
+#xhost -localhost

--- a/dockerfiles/quartus_compile.sh
+++ b/dockerfiles/quartus_compile.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This is an example script for compiling the firmware using the
+# "Quartus" software in a docker container.  This is an example - you
+# may need to copy this file and modify it so that it works in your
+# environment.
+#
+# Prior to running this script, the docker image should have been
+# created with something like:
+#  docker build -t quartus -f quartus.docker
+
+# Obtain directory of the haasoscope software (based on the location
+# of this script) and map the local firmware directory to /project .
+SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+DPARAM="-v ${SRCDIR}/max10_adc_firmware:/project -w /project"
+
+# Run Quartus compiler in container
+docker run -it --rm ${DPARAM} localhost/quartus quartus_sh --flow compile serial1.qpf

--- a/dockerfiles/quartus_flash.sh
+++ b/dockerfiles/quartus_flash.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# This is an example script for uploading new code to an fpga using
+# the "Quartus" software in a docker container.  This is an example -
+# you may need to copy this file and modify it so that it works in
+# your environment.
+#
+# Prior to running this script, the docker image should have been
+# created with something like:
+#  docker build -t quartus -f quartus.docker
+
+# Map "USB Blaster" into container
+USBBLASTER_VIDPID="09fb:6001"
+BD="`lsusb -d ${USBBLASTER_VIDPID}`" # "Bus 003 Device 043: ..."
+BUS="${BD:4:3}"
+DEV="${BD:15:3}"
+DPARAM="--device=/dev/bus/usb/${BUS}/${DEV}"
+
+# Obtain directory of the haasoscope software (based on the location
+# of this script) and map the local firmware directory to /project .
+SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+DPARAM="${DPARAM} -v ${SRCDIR}/max10_adc_firmware:/project -w /project"
+
+# Run Quartus in container
+docker run -it --rm ${DPARAM} localhost/quartus bash -c 'quartus_pgm -l && quartus_pgm -m jtag -o "p;output_files/serial1.sof"'


### PR DESCRIPTION
The Quartus software is needed to build the FPGA firmware.  Alas, that software is a bit unwieldy - it is a large download and requires a significant amount of disk space.  It can be convenient to place the installation in a container.

This PR adds a dockerfile that can download and install the latest version (v22.1) of "Quartus Prime Lite".  It also adds some example scripts for launching the GUI, simulating/compiling the FPGA firmware, and flashing that firmware to a target board.

-Kevin