### PR TITLE
Fix crash/stability/readout bugs found in review

### DIFF
--- a/software/HaasoscopeQt.py
+++ b/software/HaasoscopeQt.py
@@ -4,7 +4,7 @@ pyqtgraph widget with UI template created with Qt Designer
 """
 
 import numpy as np
-import sys, time
+import sys, time, traceback
 from serial import SerialException
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtWidgets, QtGui, loadUiType
@@ -265,8 +265,8 @@ class MainWindow(TemplateBaseClass):
                 d.increment_clk_phase(theboard)
             else:
                 if trigboardport!="": trigboard.increment_trig_board_clock_phase()
-        if event.key()==QtCore.Qt.Key_1: trigboard.set_prescale(0.1)
-        if event.key()==QtCore.Qt.Key_2: trigboard.set_prescale(0.2)
+        if event.key()==QtCore.Qt.Key_1 and trigboardport!="": trigboard.set_prescale(0.1)
+        if event.key()==QtCore.Qt.Key_2 and trigboardport!="": trigboard.set_prescale(0.2)
         if event.key()==QtCore.Qt.Key_C: d.toggle_checkfastusbwriting()
 
     def actionRead_from_file(self):
@@ -456,7 +456,7 @@ class MainWindow(TemplateBaseClass):
             self.fftui.show()
             d.dofft = True
         else:
-            self.fftui.close()
+            if hasattr(self,"fftui"): self.fftui.close() # may be unchecked before ever opened
             d.dofft = False
 
     def persist(self):
@@ -470,7 +470,7 @@ class MainWindow(TemplateBaseClass):
         else:
             d.recorddata=False; d.recorddatachan=d.selectedchannel; d.recordedchannel=[]
             print("recorddata now",d.recorddata)
-            self.persistui.close()
+            if hasattr(self,"persistui"): self.persistui.close() # may be unchecked before ever opened
 
     def drawing(self):
         if self.ui.drawingCheck.checkState() == QtCore.Qt.Checked:
@@ -481,19 +481,22 @@ class MainWindow(TemplateBaseClass):
             print("drawing now",d.dodrawing)
 
     def record(self):
-        self.savetofile = not self.savetofile
-        if self.savetofile:
-            fname="xxx"
-            if self.doh5:
-                fname="Haasoscope_out_" + time.strftime("%Y%m%d-%H%M%S") + ".h5"
-                self.outf = h5py.File(fname,"w")
-            else:
-                fname="Haasoscope_out_" + time.strftime("%Y%m%d-%H%M%S") + ".csv"
-                self.outf = open(fname,"wt")
+        if not self.savetofile: # start recording
+            fname="Haasoscope_out_" + time.strftime("%Y%m%d-%H%M%S") + (".h5" if self.doh5 else ".csv")
+            try:
+                self.outf = h5py.File(fname,"w") if self.doh5 else open(fname,"wt")
+            except Exception as e:
+                # don't flip savetofile until the file is actually open, or later
+                # outf.close()/writes hit an undefined/half-open self.outf
+                print("could not open record file",fname,":",e)
+                self.ui.statusBar.showMessage("could not open record file: "+fname)
+                return
+            self.savetofile = True
             self.ui.statusBar.showMessage("now recording to file: "+fname)
             self.ui.actionRecord.setText("Stop recording")
-        else:
-            self.outf.close()
+        else: # stop recording
+            self.savetofile = False
+            if hasattr(self,"outf"): self.outf.close()
             self.ui.statusBar.showMessage("stopped recording to file")
             self.ui.actionRecord.setText("Record to file")
     
@@ -612,8 +615,32 @@ class MainWindow(TemplateBaseClass):
         if hasattr(self,"persistui"):
             self.persistui.close()
 
+    def stopacquisition(self):
+        # Cleanly halt the acquisition timers (e.g. after a fatal serial/device error)
+        # instead of sys.exit() from inside a Qt timer callback, which Qt swallows and
+        # leaves the GUI in a zombie state.
+        self.timer.stop()
+        self.timer2.stop()
+        d.paused=True
+        d.timedout=True # so the rest of updateplot doesn't draw/save stale data
+        self.ui.runButton.setChecked(False)
+        self.ui.statusBar.showMessage("Acquisition stopped (see console for the error)")
+
     decodelabels = []
+    firstpersist = True # default so the persist-draw path never reads it unset
+    _busy = False # reentrancy guard: app.processEvents() can re-fire the timers mid-update
     def updateplot(self):
+        if self._busy: return # don't let processEvents() re-enter while we're mid-update
+        self._busy = True
+        try:
+            self._updateplot()
+        except Exception:
+            traceback.print_exc()
+            self.stopacquisition() # stop rather than let the timer storm-repeat the error
+        finally:
+            self._busy = False
+
+    def _updateplot(self):
         self.mainloop()
         if d.timedout: return # don't draw old junk if there was a timeout getting data (as often the case with no rolling trigger)
         if self.savetofile: self.dosavetofile()
@@ -653,7 +680,8 @@ class MainWindow(TemplateBaseClass):
                 self.image1.setImage(image=d.recorded2d,opacity=0.5)
             self.image1.setRect(QtCore.QRectF(d.min_x,d.min_y,d.max_x-d.min_x,d.max_y-d.min_y))
             self.persistui.ui.plot.setLabel('bottom', d.xlabel)
-            self.bar = pg.ColorBarItem(interactive=False, values= (0, np.max(d.recorded2d)), cmap=self.cmap)
+            barmax = np.max(d.recorded2d) if d.recorded2d.size else 1 # np.max raises on an empty array
+            self.bar = pg.ColorBarItem(interactive=False, values= (0, barmax), cmap=self.cmap)
             self.bar.setImageItem(self.image1)
             if not self.persistui.isVisible(): # closed the fft window
                 d.recorddata = False
@@ -666,7 +694,7 @@ class MainWindow(TemplateBaseClass):
                 resulttext,resultstart,resultend = d.decode()
                 #print(resulttext,resultstart, d.min_x, d.max_x, d.xscale, d.xscaling)
                 item=0
-                while item<len(resulttext):
+                while item<min(len(resulttext),len(resultstart)): # lists can differ on partial data
                     label = pg.TextItem(resulttext[item])
                     label.setColor(self.linepens[d.selectedchannel].color())
                     x=d.min_x+resultstart[item]*1e9/d.xscaling
@@ -732,10 +760,10 @@ class MainWindow(TemplateBaseClass):
             try: status=d.getchannels()
             except SerialException:
                 print("Serial exception getting channels!!")
-                sys.exit(1)
-            except DeviceError:
+                self.stopacquisition(); return
+            except HaasoscopeLibQt.DeviceError: # qualified - DeviceError isn't a global in this module
                 print("Device error")
-                sys.exit(1)
+                self.stopacquisition(); return
             if status==2: self.selectchannel() #we updated the switch data
             if d.db: print(time.time()-d.oldtime,"done with evt",self.nevents)
             self.nevents += 1
@@ -762,16 +790,23 @@ class MainWindow(TemplateBaseClass):
             if d.getone and not d.timedout: self.dostartstop()
 
     def drawtext(self): # happens once per second
-        d.tellrolltrig(d.rolltrigger) #because sometimes the message had been lost
-        self.ui.textBrowser.setText(d.chantext())
-        self.ui.textBrowser.append("trigger threshold: " + str(round(self.hline,3)))
-        if trigboardport!="" and trigboard.extclock:
-            delaycounters = trigboard.get_delaycounters()
-            self.ui.textBrowser.append("delay counters: "+str(delaycounters))
-            self.ui.textBrowser.append(trigboard.get_histos())
-            for b in range(HaasoscopeLibQt.num_board):
-                if not delaycounters[b]:
-                    d.increment_clk_phase(b,30) # increment clk of that board by 30*100ps=3ns
+        if self._busy: return # don't run while updateplot is talking to the same serial port
+        self._busy = True
+        try:
+            d.tellrolltrig(d.rolltrigger) #because sometimes the message had been lost
+            self.ui.textBrowser.setText(d.chantext())
+            self.ui.textBrowser.append("trigger threshold: " + str(round(self.hline,3)))
+            if trigboardport!="" and trigboard.extclock:
+                delaycounters = trigboard.get_delaycounters()
+                self.ui.textBrowser.append("delay counters: "+str(delaycounters))
+                self.ui.textBrowser.append(trigboard.get_histos())
+                for b in range(HaasoscopeLibQt.num_board):
+                    if b<len(delaycounters) and not delaycounters[b]:
+                        d.increment_clk_phase(b,30) # increment clk of that board by 30*100ps=3ns
+        except Exception:
+            traceback.print_exc() # a hiccup here shouldn't kill the once-a-second timer
+        finally:
+            self._busy = False
 
 if __name__ == '__main__':
     import libs.HaasoscopeLibQt as HaasoscopeLibQt

--- a/software/HaasoscopeQt.py
+++ b/software/HaasoscopeQt.py
@@ -774,7 +774,9 @@ class MainWindow(TemplateBaseClass):
                 lastrate = round(self.tinterval/elapsedtime,2)
                 if d.dologicanalyzer: nchan = HaasoscopeLibQt.num_chan_per_board + 1
                 else: nchan = HaasoscopeLibQt.num_chan_per_board
-                print(self.nevents,"events,",lastrate,"Hz",round(lastrate*HaasoscopeLibQt.num_board*d.num_samples*nchan/1e6,3),"MB/s")
+                badmsg = " ("+str(d.nbadevents)+" bad)" if d.nbadevents>0 else ""
+                print(self.nevents,"events,",lastrate,"Hz",round(lastrate*HaasoscopeLibQt.num_board*d.num_samples*nchan/1e6,3),"MB/s"+badmsg)
+                d.nbadevents = 0 # reset the bad-event counter for the next interval
                 if lastrate>40: self.tinterval=500.
                 else: self.tinterval=100.
                 self.oldnevents=self.nevents

--- a/software/libs/HaasoscopeLibQt.py
+++ b/software/libs/HaasoscopeLibQt.py
@@ -1407,6 +1407,7 @@ class Haasoscope():
         return True
 
     timedout = False
+    nbadevents = 0 # count of short/timed-out reads since the last status print (shown in the status line)
 
     def try_low_latency(self):
         # Enable serial low-latency mode where supported (Linux/pyserial>=3.5).
@@ -1531,7 +1532,7 @@ class Haasoscope():
             if self.dooversample[num_chan_per_board*(num_board-board-1)]==9: self.overoversample(0,1)
         else:
             self.timedout = True
-            if not self.db and self.rollingtrigger: print("getdata asked for",self.num_bytes,"bytes and got",len(rslt),"from board",board)
+            if not self.db and self.rollingtrigger: self.nbadevents += 1 # short read; counted in the status line instead of printed
             if not self.dousb: self.drain_serial() # re-sync the serial link before the next event
         if self.dologicanalyzer:
             #get extra logic analyzer data, if needed
@@ -1563,7 +1564,7 @@ class Haasoscope():
             if len(rslt)==logicbytes+padding:
                 self.ydatalogic=np.frombuffer(rslt,dtype=np.uint8,count=self.num_samples,offset=padding-endpadding)
             else:
-                if not self.db and self.rollingtrigger: print("getdata asked for",logicbytes,"logic bytes and got",len(rslt),"from board",board)
+                if not self.db and self.rollingtrigger: self.nbadevents += 1 # short logic read; counted in the status line instead of printed
                 if not self.dousb: self.drain_serial() # re-sync the serial link before the next event
 
     def oversample(self,c1,c2):

--- a/software/libs/HaasoscopeLibQt.py
+++ b/software/libs/HaasoscopeLibQt.py
@@ -61,6 +61,15 @@ if enable_fastusb:
         print("Warning... fastusb drivers not installed?")
         enable_fastusb=False
 
+# Always provide a module-level DeviceError so `except DeviceError` clauses (here
+# and in HaasoscopeQt.py) never raise NameError on platforms/builds where ftd2xx
+# isn't imported - on macOS/Linux we use pyftdi, which doesn't define DeviceError.
+try:
+    DeviceError
+except NameError:
+    class DeviceError(Exception):
+        pass
+
 class Haasoscope():
     
     def __init__(self):
@@ -1487,6 +1496,7 @@ class Haasoscope():
                 raise DeviceError(str(e))
             except Exception as e:
                 print(type(e).__name__, "Error reading from USB2", self.usbsermap[board])
+                self.timedout = True # so the caller doesn't redraw/save the previous (stale) event
                 return
         else:
             rslt = self.read_serial_exact(int(self.num_bytes))
@@ -1655,9 +1665,10 @@ class Haasoscope():
                 if self.db: print(time.time()-self.oldtime,"getting board",bn)
                 try:
                     self.parent_conn[bn].send([self.num_samples, self.fastusbpadding, self.fastusbendpadding, self.yscale, self.dologicanalyzer, self.rollingtrigger])
-                except:
-                    print("could not send message to receiver",bn,"- Exiting!")
-                    sys.exit(-3)
+                except Exception as e:
+                    # A dead worker means we can't read this cycle; raise so the GUI's
+                    # timer handler stops acquisition cleanly instead of hard-exiting.
+                    raise RuntimeError("could not send message to receiver "+str(bn)) from e
                 xboardshift=(11.0*bn/8.0)/pow(2,max(self.downsample,0)) # shift the board data to the right by this number of samples (to account for the readout delay) #downsample isn't less than 0 for xscaling
                 xdatanew = (self.xdata-xboardshift-self.num_samples/2.)*(1000.0*pow(2,max(self.downsample,0))/self.clkrate/self.xscaling) #downsample isn't less than 0 for xscaling
                 xdatanew = xdatanew[1:len(xdatanew)]
@@ -1787,7 +1798,10 @@ class Haasoscope():
                 self.xydatalogicraw_array = multiprocessing.RawArray("B", self.xydatalogicraw.size)  # a byte is 1 byte
                 self.xydatalogicraw = np.frombuffer(self.xydatalogicraw_array, dtype=np.uint8).reshape(self.xydatalogicraw.shape)
                 self.parent_conn=[]
-                multiprocessing.set_start_method('spawn')
+                try:
+                    multiprocessing.set_start_method('spawn')
+                except RuntimeError:
+                    pass # already set (e.g. on a re-init) - setting it twice raises
                 for bn in range(num_board):
                     parent_conn, child_conn = multiprocessing.Pipe()
                     self.parent_conn.append(parent_conn)
@@ -1947,6 +1961,7 @@ def receiver(name, conn, padding,num_samples,xydata_shape,xydata_array,xydatalog
                 elif not dologicanalyzer and dologicanalyzer!=olddologic:
                     olddologic=dologicanalyzer
                     usb.read_data_set_chunksize( int((num_bytes + fastusbpadding*num_chan_per_board) * 514/512 + 100) )
+            rslt = b"" # so a read exception below can't leave it unbound (UnboundLocalError)
             try:
                 nb = num_bytes+padding*num_chan_per_board
                 if useftd2xx: rslt = usb.read(nb)#,cache=True)
@@ -1957,7 +1972,7 @@ def receiver(name, conn, padding,num_samples,xydata_shape,xydata_array,xydatalog
                         print(nq, "bytes still available for usb on board", board, "...purging")
                         if useftd2xx: usb.purge(ftd.defines.PURGE_RX)
                         elif useftdi: usb.purge_rx_buffer()
-            except ftd.DeviceError as msgnum:
+            except Exception as msgnum: # ftd.DeviceError isn't defined on the pyftdi path
                 print("Error reading from USB2 on board", board, msgnum)
                 returnmsg = "read err"
             if len(rslt)==num_bytes+padding*num_chan_per_board:
@@ -1986,7 +2001,7 @@ def receiver(name, conn, padding,num_samples,xydata_shape,xydata_array,xydatalog
                         if nq > 0:
                             print(nq, "bytes still available for usb on board", board, "...purging")
                             usb.purge(ftd.defines.PURGE_RX)
-                except ftd.DeviceError as msgnum:
+                except Exception as msgnum: # ftd.DeviceError isn't defined on the pyftdi path
                     print("Error reading from USB2 on board", board, msgnum)
                     returnmsg = "read err"
                 if len(rslt)==logicbytes+padding:

--- a/software/libs/HaasoscopeTrigLibQt.py
+++ b/software/libs/HaasoscopeTrigLibQt.py
@@ -11,7 +11,14 @@ class HaasoscopeTrig:
         self.extclock=0
         self.histostosend=-1
         self.dorolling=1
+        self.delaycounters=(0,)*16 # last known counters; safe default if a read is short
         print("connected trigboard serial to", port)
+
+    def _drain(self):
+        # Discard any leftover bytes after a short read so the next command's
+        # response doesn't get prepended with this one's tail (serial desync).
+        try: self.ser.reset_input_buffer()
+        except Exception: pass
     
     def togglerolling(self):
         self.dorolling = not self.dorolling
@@ -32,6 +39,7 @@ class HaasoscopeTrig:
             self.ser.write(bytearray([4]))  # toggle use other clk input
         self.ser.write(bytearray([8]))  # active clock info
         res = self.ser.read(1)
+        if len(res)==0: return # short read on timeout - don't index an empty buffer
         b = unpack('%dB' % len(res), res)
         print("trig board now using clock", b[0])
         self.extclock = b[0]
@@ -75,6 +83,10 @@ class HaasoscopeTrig:
     def get_delaycounters(self):
         self.ser.write(bytearray([11]))  # delaycounter trigger info
         res = self.ser.read(16)
+        if len(res)!=16: # short read - keep the last good counters and resync the link
+            print("trigboard get_delaycounters short read:",len(res),"bytes")
+            self._drain()
+            return self.delaycounters
         self.delaycounters = unpack('%dB' % len(res), res)
         #print("all delaycounters:",self.delaycounters)
         return self.delaycounters
@@ -87,6 +99,10 @@ class HaasoscopeTrig:
     def get_histos(self):
         self.ser.write(bytearray([10])) # get histos
         res = self.ser.read(32)
+        if len(res)!=32: # short read - don't index past the buffer; resync the link
+            print("trigboard get_histos short read:",len(res),"bytes")
+            self._drain()
+            return "histos for board"+str(self.histostosend)+": (short read)"
         b = unpack('%dB' % len(res), res)
         mystr="histos for board"+str(self.histostosend)+": "
         myint=[]
@@ -97,7 +113,9 @@ class HaasoscopeTrig:
         return mystr
 
     def cleanup(self):
-        self.setclock(False)
-        if not self.dorolling: self.togglerolling()
-        self.ser.close()
+        try:
+            self.setclock(False)
+            if not self.dorolling: self.togglerolling()
+        finally:
+            self.ser.close() # always release the port, even if a command above failed
     


### PR DESCRIPTION
Stacked on #84. Fixes 13 concrete bugs found auditing the readout/GUI/trigger code for crashes, GUI freezes, and readout-correctness issues.

> **Note:** targets `serial-robustness` (#84), not `master`, so this diff shows only the bugfix commit. Merge #84 first, or merge this into that branch.

## `libs/HaasoscopeLibQt.py`
- Module-level `DeviceError` fallback so `except DeviceError` never raises `NameError` on macOS/Linux (ftd2xx isn't imported there).
- `receiver` worker: initialize `rslt` before the read (no `UnboundLocalError` killing the worker process); catch `Exception` instead of `ftd.DeviceError` (undefined on the pyftdi path) in both read blocks.
- `getdata`: set `timedout` on a caught USB read error so the caller doesn't redraw/save the previous (stale) event.
- Guard `multiprocessing.set_start_method('spawn')` against `RuntimeError` on re-init.
- `getchannels`: raise instead of `sys.exit(-3)` on a worker pipe-send failure, so the GUI can stop cleanly.

## `libs/HaasoscopeTrigLibQt.py`
- Guard the second read in `setclock()` against a short read (`IndexError`).
- `get_delaycounters()` / `get_histos()`: handle short reads (return last-good / placeholder) and drain the port to resync instead of indexing past the buffer.
- `cleanup()`: close the serial port in a `finally` so it's always released.

## `HaasoscopeQt.py`
- Reference `HaasoscopeLibQt.DeviceError` (was an undefined global) and stop acquisition cleanly instead of `sys.exit()` from inside the Qt timer callback.
- Wrap `updateplot` in try/except + a reentrancy guard shared with `drawtext`, so an exception or `processEvents()` re-entry can't kill or overlap acquisition.
- Guard short reads / empty arrays in the persist colorbar and decode label loop.
- Guard `trigboard` keypresses, `fft`/`persist`/`record` close, and only flip `savetofile` after the record file actually opens.

## Testing
- All files pass `py_compile`; modules import and `Haasoscope()` instantiates cleanly.
- Not yet exercised against real hardware — worth a bench test before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)